### PR TITLE
Fix type-error in translate_optim test

### DIFF
--- a/src/translation.jl
+++ b/src/translation.jl
@@ -2,16 +2,18 @@
 export translate, translate_optim
 
 function translationclossure(mm,movement)
-        function translation_loss(matrix)
+    function translation_loss(matrix)
 		c = reshape(matrix,2,2) * movement
 		c .+= (size(mm,1)+1)/2
-		loss = 0
-                for i in size(c,2)
-			loss += mm[c[1,i],c[2,i],i]
-		end
-		return loss
+		loss = zero(eltype(mm))
+        for i in size(c,2)
+            idx1, idx2 = c[1,i], c[2,i]
+            checkbounds(Bool, mm, idx1, idx2, i) || return typemax(loss)
+			loss += mm[idx1,idx2,i]
         end
-        return translation_loss
+		return loss
+    end
+    return translation_loss
 end
 
 function translate(fixed, moving, maxshift, thresh=nothing)

--- a/test/register_test.jl
+++ b/test/register_test.jl
@@ -8,10 +8,12 @@
 	mm[:,:,1] = translate(A,A,(5,5))
 	mm[:,:,2] = translate(A,B,(5,5))
 	mm[:,:,3] = translate(A,C,(5,5))
-	
+
 	move = [0 1 2;0 0 0]
-	matrix  = [1 1 1 1]
+	matrix  = Float64[1 1 1 1]
 	result = translate_optim(mm,matrix,move)
+
+	@test minimum(result) < 1e-3
 end
 
 


### PR DESCRIPTION
Optim should probably not take the element type of the initial position so seriously, but we can fix a `Int(NaN)` error by ensuring that the initial position uses `Float64` for its `eltype`.

This also checks bounds on the loss function, to ensure we don't get a `BoundsError` if you try to access displacements that haven't been cached in mm.