### PR TITLE
Add [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,20 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+CoordinateTransformations = "0.6"
 FileIO = "1"
+ImageSegmentation = "1"
+ImageTransformations = "0.8"
+Images = "0.24, 0.25"
+ImagineFormat = "1"
+Interpolations = "0.13"
+OffsetArrays = "1"
+Optim = "1"
+PaddedViews = "0.5"
+ProgressMeter = "1"
+RegisterMismatch = "0.3"
+Rotations = "1"
+StaticArrays = "1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This specifies the package versions you support. This means that if the developers of those packages someday release breaking changes to their packages, it won't break your package, because you'll still be using the older one. When you want to upgrade to a newer version, just edit the `[compat]` section to include the new version, then run the tests, and fix any breakages. This allows you to control the schedule by which you update your dependencies.

More info is available at https://pkgdocs.julialang.org/v1.6/compatibility/

Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11
Closes #12
Closes #14
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24
