### PR TITLE
Move ImageView integration to extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,15 +6,12 @@ version = "0.1.0"
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-GtkObservables = "8710efd8-4ad6-11eb-33ea-2d5ceb25a41c"
 ImageMorphology = "787d08f9-d448-5407-9aad-5290dd7ab264"
 ImageSegmentation = "80713f31-8817-5129-9cf8-209ff8fb23e1"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
-ImageView = "86fae568-95e7-573e-a6b2-d8a6b900c9ef"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 ImagineFormat = "4bab44a2-5ff2-5a6b-8e10-825fb9ac126a"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 PaddedViews = "5432bcbf-9aad-5242-b902-cca2824c8663"
@@ -24,6 +21,14 @@ RegisterMismatch = "3c0dd727-6833-5f5d-a1e8-c0d421935c74"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[weakdeps]
+GtkObservables = "8710efd8-4ad6-11eb-33ea-2d5ceb25a41c"
+ImageView = "86fae568-95e7-573e-a6b2-d8a6b900c9ef"
+Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
+
+[extensions]
+REALMSupportImageViewExt = ["GtkObservables", "ImageView", "Observables"]
 
 [compat]
 CoordinateTransformations = "0.6"
@@ -44,7 +49,7 @@ ProgressMeter = "1"
 RegisterMismatch = "0.3, 0.4"
 Rotations = "1"
 StaticArrays = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ext/REALMSupportImageViewExt.jl
+++ b/ext/REALMSupportImageViewExt.jl
@@ -1,3 +1,5 @@
+module REALMSupportImageViewExt
+
 using Observables
 using GtkObservables
 using GtkObservables.Gtk4: GtkEventControllerKey, signal_connect
@@ -12,7 +14,7 @@ the mouse over desired point. The points are recorded in `pointfile` as a CSV fi
 
 Press 'q' to quit (the window will close).
 """
-function record_points(pointfile::AbstractString, img; overwrite::Bool=false)
+function REALMSupport.record_points(pointfile::AbstractString, img; overwrite::Bool=false)
     dct = imshow(img)
     win = dct["gui"]["window"]
     canvas = dct["gui"]["canvas"]
@@ -37,4 +39,6 @@ function record_points(pointfile::AbstractString, img; overwrite::Bool=false)
         end
     end
     return dct
+end
+
 end

--- a/src/REALMSupport.jl
+++ b/src/REALMSupport.jl
@@ -18,6 +18,8 @@ include("translation.jl")
 include("segmentbeads.jl")
 include("s_save_image.jl")
 include("time.jl")
-include("click_gui.jl")
+
+# stubs for extensions
+function record_points end
 
 end


### PR DESCRIPTION
This allows REALMSupport to be independent of ImageView but still preserve the integration. This is useful when a display is not available.

I know about #42 and will use that in practice, but this illustrates how one can preserve the ImageView-based version while still successfully compiling without a display.